### PR TITLE
Allow to configure the bit-depth of the adc.

### DIFF
--- a/FastCapacitiveSensor.cpp
+++ b/FastCapacitiveSensor.cpp
@@ -37,6 +37,7 @@ unsigned long FastCapacitiveSensor::touch() {
     while (analogRead(receivePin) < inputThreshold) {
       unsigned long t1 = micros() - starttim;
       if (t1 > breakThreshold) {
+         // for some reason it works better if we do anther read here
         int v1 = analogRead(receivePin);
         val = t1 * logf(1.0 - 0.9) / logf(1.0 - ((float)v1 / (float)adcmax));
         break;

--- a/FastCapacitiveSensor.cpp
+++ b/FastCapacitiveSensor.cpp
@@ -1,21 +1,21 @@
 #include "FastCapacitiveSensor.h"
 #include <math.h>
 
-FastCapacitiveSensor::FastCapacitiveSensor(int sendPin, int receivePin, int frequency, int breakThreshold, double exceptRatio, int adcBits) : sendPin(sendPin), receivePin(receivePin), numReads(frequency), breakThreshold(breakThreshold), exceptRatio(exceptRatio)  {
+FastCapacitiveSensor::FastCapacitiveSensor(int sendPin, int receivePin, int frequency, int breakThreshold, float exceptRatio, int adcBits) : sendPin(sendPin), receivePin(receivePin), numReads(frequency), breakThreshold(breakThreshold), exceptRatio(exceptRatio)  {
   adcmax = 1 << adcBits;
   inputThreshold = adcmax * 0.9;
   except = frequency * exceptRatio;
   use = frequency - 2 * except;
 }
 
-static void swap(double* a, double* b) {
-  double c = *a;
+static void swap(float* a, float* b) {
+  float c = *a;
   *a = *b;
   *b = c;
 }
 
-static void sort(double* array) {
-  int size = sizeof(array) / sizeof(double);
+static void sort(float* array) {
+  int size = sizeof(array) / sizeof(float);
   for(int i = 0;i < size;i++)
     for(int j = size - 1;j > i; j--)
       if(array[j] < array[j - 1])
@@ -27,18 +27,18 @@ void FastCapacitiveSensor::begin() {
   pinMode(receivePin, INPUT);
 }
 
-double FastCapacitiveSensor::touch() {
-  double values[numReads];
+unsigned long FastCapacitiveSensor::touch() {
+  float values[numReads];
 
   for (int i = 0; i < numReads; i++) {
-    double val = 0;
+    float val = 0;
     digitalWrite(sendPin, HIGH);
     unsigned long starttim = micros();
     while (analogRead(receivePin) < inputThreshold) {
       unsigned long t1 = micros() - starttim;
       if (t1 > breakThreshold) {
         int v1 = analogRead(receivePin);
-        val = t1 * log(1.0 - 0.9) / log(1.0 - ((double)v1 / (double)adcmax));
+        val = t1 * logf(1.0 - 0.9) / logf(1.0 - ((float)v1 / (float)adcmax));
         break;
       }
     }
@@ -53,8 +53,8 @@ double FastCapacitiveSensor::touch() {
   if (except > 0) {
     sort(values);
   }
-  double sum = 0;
+  float sum = 0;
   for (int i = except;i < numReads - except;i++)
     sum += values[i];
-  return sum / use;
+  return (unsigned long)(sum / use);
 }

--- a/FastCapacitiveSensor.cpp
+++ b/FastCapacitiveSensor.cpp
@@ -53,7 +53,9 @@ double FastCapacitiveSensor::touch() {
     } else
       i--;
   }
-  sort(VAL);
+  if (EXCEPT > 0) {
+    sort(VAL);
+  }
   double VALsum = 0;
   for (int i = EXCEPT;i < FREQUENCY - EXCEPT;i++)
     VALsum += VAL[i];

--- a/FastCapacitiveSensor.cpp
+++ b/FastCapacitiveSensor.cpp
@@ -18,18 +18,19 @@ static void sort(double* array) {
         swap(&array[j], &array[j - 1]);
 }
 
-void FastCapacitiveSensor::begin(int send, int receive, double voltage, int frequency, int breakthreshold, double exceptratio) {
+void FastCapacitiveSensor::begin(int send, int receive, double voltage, int frequency, int breakthreshold, double exceptratio, int adcBits) {
   SEND = send;
   RECEIVE = receive;
   VOLTAGE = voltage;
   FREQUENCY = frequency;
   BREAKTHRESHOLD = breakthreshold;
   EXCEPTRATIO = exceptratio;
+  ADCMAX = 1 << adcBits;
 }
 
 double FastCapacitiveSensor::touch() {
   double VAL[FREQUENCY];
-  double INPUTTHRESHOLD = VOLTAGE * 1024 / 5 * 0.9;
+  double INPUTTHRESHOLD = VOLTAGE * ADCMAX / 5 * 0.9;
 
   for (int i = 0; i < FREQUENCY; i++) {
     double val = 0;

--- a/FastCapacitiveSensor.h
+++ b/FastCapacitiveSensor.h
@@ -5,19 +5,18 @@
 
 class FastCapacitiveSensor {
 public:
-  FastCapacitiveSensor();
-  void begin(int send, int receive, int frequency, int breakthreshold, double exceptratio, int adcBits=10);
+  FastCapacitiveSensor(int sendPin, int receivePin, int numReads, int breakThreshold, double exceptRatio, int adcBits=10);
+  void begin();
   double touch();
 
 private:
-  int FREQUENCY;
-  int BREAKTHRESHOLD;
-  double EXCEPTRATIO;
-  int SEND;
-  int RECEIVE;
-  int ADCMAX;
-  double INPUTTHRESHOLD;
-  int EXCEPT, USE;
+  int numReads;
+  int breakThreshold;
+  double exceptRatio;
+  int sendPin, receivePin;
+  int adcmax;
+  double inputThreshold;
+  int except, use;
 };
 
 #endif

--- a/FastCapacitiveSensor.h
+++ b/FastCapacitiveSensor.h
@@ -6,7 +6,7 @@
 class FastCapacitiveSensor {
 public:
   FastCapacitiveSensor();
-  void begin(int send, int receive, double voltage, int frequency, int breakthreshold, double exceptratio, int adcBits=10);
+  void begin(int send, int receive, int frequency, int breakthreshold, double exceptratio, int adcBits=10);
   double touch();
 
 private:
@@ -15,8 +15,9 @@ private:
   double EXCEPTRATIO;
   int SEND;
   int RECEIVE;
-  double VOLTAGE;
   int ADCMAX;
+  double INPUTTHRESHOLD;
+  int EXCEPT, USE;
 };
 
 #endif

--- a/FastCapacitiveSensor.h
+++ b/FastCapacitiveSensor.h
@@ -5,17 +5,17 @@
 
 class FastCapacitiveSensor {
 public:
-  FastCapacitiveSensor(int sendPin, int receivePin, int numReads, int breakThreshold, double exceptRatio, int adcBits=10);
+  FastCapacitiveSensor(int sendPin, int receivePin, int numReads, int breakThreshold, float exceptRatio, int adcBits=10);
   void begin();
-  double touch();
+  unsigned long touch();
 
 private:
   int numReads;
   int breakThreshold;
-  double exceptRatio;
+  float exceptRatio;
   int sendPin, receivePin;
   int adcmax;
-  double inputThreshold;
+  float inputThreshold;
   int except, use;
 };
 

--- a/FastCapacitiveSensor.h
+++ b/FastCapacitiveSensor.h
@@ -6,7 +6,7 @@
 class FastCapacitiveSensor {
 public:
   FastCapacitiveSensor();
-  void begin(int send, int receive, double voltage, int frequency, int breakthreshold, double exceptratio);
+  void begin(int send, int receive, double voltage, int frequency, int breakthreshold, double exceptratio, int adcBits=10);
   double touch();
 
 private:
@@ -16,6 +16,7 @@ private:
   int SEND;
   int RECEIVE;
   double VOLTAGE;
+  int ADCMAX;
 };
 
 #endif

--- a/README.md
+++ b/README.md
@@ -82,4 +82,4 @@ This will configure the pin-modes.
 sensor1.touch()
 ```
 
-The return value is the sensed (or calculated) time in units of micro seconds. The type is double.
+The return value is the sensed (or calculated) time in units of micro seconds. The type is `unsigned long`.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ sensor1.begin(A0, A1, 5.0, 10, 10, 0.2);
 arguments:
 
 ```c++
-void begin(sendPin, receivePin, maxVoltage, frequency, breakThreshold, excludeRatio);
+void begin(sendPin, receivePin, maxVoltage, frequency, breakThreshold, excludeRatio, adcBits);
 ```
 sendPin is a pin that you can use the function digitalWrite on.
 
@@ -73,6 +73,8 @@ frequency is how many times the touch function tries sensing.
 breakThreshold is the threshold of breaking sensing. The unit is micro seconds. the touch function finish sensing on the breakThreshold time, and after that, calculate the expected time of sensing. It is $t_1$.
 
 excludeRatio is the ratio of exclusion of sensed values. Must be larger than or the same as 0 and smaller than 0.5.
+
+adcBits is the bit-depth of the analog-digital converter. It is by default 10, but some miccontrollers suport higher bit-depths via analogReadResolution().
 
 ### Sense
 

--- a/README.md
+++ b/README.md
@@ -45,36 +45,36 @@ See also example program.
 #include <FastCapacitiveSensor.h>
 ```
 
-### Define a class
+### Define an instance
 
 ```c++
-FastCapacitiveSensor sensor1;
-```
-
-### Execute begin function
-
-```c++
-sensor1.begin(A0, A1, 5.0, 10, 10, 0.2);
+FastCapacitiveSensor sensor1(A0, A1, 10, 10, 0.2);
 ```
 
 arguments:
 
 ```c++
-void begin(sendPin, receivePin, maxVoltage, frequency, breakThreshold, excludeRatio, adcBits);
+void begin(sendPin, receivePin, numReads, breakThreshold, excludeRatio, adcBits);
 ```
 sendPin is a pin that you can use the function digitalWrite on.
 
 receivePin is read out with analogRead, so it should be an analog pin.
 
-maxVoltage is the voltage of the sendPin. It is $V_0$.
-
-frequency is how many times the touch function tries sensing.
+numReads is how many times the touch function tries sensing.
 
 breakThreshold is the threshold of breaking sensing. The unit is micro seconds. the touch function finish sensing on the breakThreshold time, and after that, calculate the expected time of sensing. It is $t_1$.
 
 excludeRatio is the ratio of exclusion of sensed values. Must be larger than or the same as 0 and smaller than 0.5.
 
 adcBits is the bit-depth of the analog-digital converter. It is by default 10, but some miccontrollers suport higher bit-depths via analogReadResolution().
+
+### Execute begin function
+
+```c++
+sensor1.begin();
+```
+
+This will configure the pin-modes.
 
 ### Sense
 

--- a/examples/FastCapacitiveSensor/FastCapacitiveSensor.ino
+++ b/examples/FastCapacitiveSensor/FastCapacitiveSensor.ino
@@ -1,15 +1,13 @@
 #include <FastCapacitiveSensor.h>
-FastCapacitiveSensor sensor1;
-FastCapacitiveSensor sensor2;
+// the send pin should be a pin that can be used with the digitalWrite() function
+// the receive pin MUST be an analog pin. The library uses analogRead() internally.
+FastCapacitiveSensor sensor1(A0, A1, 10, 10, 0.2);
+FastCapacitiveSensor sensor2(A2, A3, 10, 10, 0.2);
 
 void setup() {
-  pinMode(A0, OUTPUT); // the send pin should be a pin that can be used with the digitalWrite() function
-  pinMode(A1, INPUT);  // the receive pin MUST be an analog pin. The library uses analogRead() internally.
-  pinMode(A2, OUTPUT);
-  pinMode(A3, INPUT);
   Serial.begin(9600);
-  sensor1.begin(A0, A1, 5.0, 10, 10, 0.2);
-  sensor2.begin(A2, A3, 5.0, 10, 10, 0.2);
+  sensor1.begin();
+  sensor2.begin();
 }
 
 void loop() {


### PR DESCRIPTION
The wiring library supports analogReadResolution() to e.g. specify 12 bits for some MCUs.